### PR TITLE
Classifier fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ plugins {
     `java-library`
     `maven-publish`
     id("com.github.johnrengelman.shadow")
-    id("com.playmonumenta.paperweight-aw.userdev") version "1.+" // from https://maven.playmonumenta.com/releases/
+    id("com.playmonumenta.paperweight-aw.userdev") version "2.0.0-build.5+2.0.0-beta.18" // from https://maven.playmonumenta.com/releases/
 }
 
 val include by configurations.creating
@@ -33,13 +33,15 @@ val include by configurations.creating
 configurations.getByName("implementation").extendsFrom(include)
 configurations.getByName("implementation").extendsFrom(configurations.getByName("mojangMappedServerRuntime"))
 
+paperweight.reobfArtifactConfiguration = ReobfArtifactConfiguration.REOBF_PRODUCTION
+
 dependencies {
     paperweight.paperDevBundle("1.20.4-R0.1-SNAPSHOT")
 
-    implementation("io.github.llamalad7:mixinextras-common:0.4.0")
-    implementation("com.floweytf.fabricpaperloader:fabric-paper-loader:1.0.1")
+    implementation("io.github.llamalad7:mixinextras-common:0.5.0")
+    implementation("com.floweytf.fabricpaperloader:fabric-paper-loader:2.0.0+fabric.0.17.2")
 
-    remapper("net.fabricmc:tiny-remapper:0.10.3") {
+    remapper("net.fabricmc:tiny-remapper:0.11.1") {
         artifact {
             classifier = "fat"
         }
@@ -53,16 +55,10 @@ tasks {
 
     shadowJar {
         archiveClassifier.set("dev")
-        configurations = listOf(include)
     }
 
     reobfJar {
-        remapperArgs.add("--mixin")
-        finalizedBy("remapAccessWidener")
-    }
-
-    build {
-        dependsOn(reobfJar)
+		remapperArgs = TinyRemapper.createArgsList() + "--mixin"
     }
 }
 ```

--- a/src/main/java/com/floweytf/fabricpaperloader/LibraryClassifier.java
+++ b/src/main/java/com/floweytf/fabricpaperloader/LibraryClassifier.java
@@ -7,11 +7,9 @@ import java.util.*;
 import java.util.zip.ZipError;
 import java.util.zip.ZipFile;
 
-import net.fabricmc.loader.api.Version;
 import net.fabricmc.loader.impl.util.log.Log;
 import net.fabricmc.loader.impl.util.log.LogCategory;
 import net.fabricmc.loader.impl.util.log.LogLevel;
-import net.fabricmc.loader.impl.util.version.VersionParser;
 
 // TODO: use fabric's own LibClassifier instead of reinventing the wheel
 public class LibraryClassifier {

--- a/src/main/java/com/floweytf/fabricpaperloader/LibraryClassifier.java
+++ b/src/main/java/com/floweytf/fabricpaperloader/LibraryClassifier.java
@@ -17,7 +17,6 @@ import net.fabricmc.loader.impl.util.version.VersionParser;
 public class LibraryClassifier {
     private final Map<LibraryCategory, List<Path>> classifications = new EnumMap<>(LibraryCategory.class);
     private final boolean shouldLog = Log.shouldLog(LogLevel.DEBUG, LogCategory.LIB_CLASSIFICATION);
-    private final Map<Path, Version> versionMap = new HashMap<>();
     private boolean isDone = false;
 
     public void addPaths(Path... paths) {
@@ -25,25 +24,6 @@ public class LibraryClassifier {
             final var type = classifySingle(path);
             if (type == null) {
                 continue;
-            }
-            try {
-                Version version = VersionParser.parseSemantic(path.getParent().getFileName().toString());
-                Path libName = path.subpath(2, path.getNameCount() - 2);
-                if (versionMap.containsKey(libName)) {
-                    int compare = version.compareTo(versionMap.get(libName));
-                    if (compare > 0) {
-                        Path olderVersionPath = Path.of(path.toString().replace(version.getFriendlyString(), versionMap.get(libName).getFriendlyString()));
-                        versionMap.put(libName, version);
-                        classifications.get(type).remove(olderVersionPath);
-                    } else {
-                        continue;
-                    }
-                } else {
-                    versionMap.put(libName, version);
-                }
-
-            } catch (Exception e) {
-                Log.warn(LogCategory.LIB_CLASSIFICATION, "failed to parse version from path %s", path);
             }
             classifications.computeIfAbsent(type, ignored -> new ArrayList<>()).add(path);
             if (shouldLog) {

--- a/src/main/java/com/floweytf/fabricpaperloader/PaperGameProvider.java
+++ b/src/main/java/com/floweytf/fabricpaperloader/PaperGameProvider.java
@@ -5,10 +5,7 @@ import com.floweytf.fabricpaperloader.paperclip.VersionInfo;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.FileSystems;
@@ -19,8 +16,6 @@ import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipFile;
 
 import net.fabricmc.loader.impl.FormattedException;
 import net.fabricmc.loader.impl.game.GameProvider;

--- a/src/main/java/com/floweytf/fabricpaperloader/paperclip/PaperclipRunner.java
+++ b/src/main/java/com/floweytf/fabricpaperloader/paperclip/PaperclipRunner.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -22,6 +23,7 @@ import net.fabricmc.loader.impl.util.log.LogCategory;
  * A utility class for containing annoying procedural logic required for running paperclip.
  */
 public class PaperclipRunner {
+    private static Path paperclipPath = Path.of("");
     /**
      * Finds paperclip with Fabric's tools.
      *
@@ -128,7 +130,7 @@ public class PaperclipRunner {
                     Log.error(LogCategory.GAME_PROVIDER, "Paperclip exited with a non-zero code");
                     return Optional.empty();
                 }
-
+                paperclipPath = paperclipLocateResult.get().path;
                 return Optional.of(version);
             } catch (Exception e) {
                 Log.error(LogCategory.GAME_PROVIDER, "Exception thrown while executing paperclip", e);
@@ -183,4 +185,9 @@ public class PaperclipRunner {
 
         return Boolean.getBoolean(name);
     }
+
+    public static Path getPaperclipPath() {
+        return paperclipPath;
+    }
+
 }

--- a/src/main/java/com/floweytf/fabricpaperloader/paperclip/PaperclipRunner.java
+++ b/src/main/java/com/floweytf/fabricpaperloader/paperclip/PaperclipRunner.java
@@ -2,8 +2,8 @@ package com.floweytf.fabricpaperloader.paperclip;
 
 import com.floweytf.fabricpaperloader.util.ReroutingCL;
 import com.floweytf.fabricpaperloader.util.Utils;
-import java.io.IOException;
-import java.io.PrintStream;
+
+import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,6 +14,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Scanner;
 import java.util.stream.Collectors;
+
 import net.fabricmc.loader.impl.game.GameProviderHelper;
 import net.fabricmc.loader.impl.util.SystemProperties;
 import net.fabricmc.loader.impl.util.log.Log;
@@ -23,7 +24,6 @@ import net.fabricmc.loader.impl.util.log.LogCategory;
  * A utility class for containing annoying procedural logic required for running paperclip.
  */
 public class PaperclipRunner {
-    private static Path paperclipPath = Path.of("");
     /**
      * Finds paperclip with Fabric's tools.
      *
@@ -118,7 +118,7 @@ public class PaperclipRunner {
             );
 
             final var hash = reader.next();
-            final var version = new VersionInfo(reader.next(), hash);
+            final var version = new VersionInfo(reader.next(), hash, getLibraryPaths(classLoader), Path.of("versions").resolve(reader.next()));
 
             Log.info(LogCategory.GAME_PROVIDER, "Found paper %s", version);
             Log.info(LogCategory.GAME_PROVIDER, "Launching paperclip to generate patched jars");
@@ -130,7 +130,6 @@ public class PaperclipRunner {
                     Log.error(LogCategory.GAME_PROVIDER, "Paperclip exited with a non-zero code");
                     return Optional.empty();
                 }
-                paperclipPath = paperclipLocateResult.get().path;
                 return Optional.of(version);
             } catch (Exception e) {
                 Log.error(LogCategory.GAME_PROVIDER, "Exception thrown while executing paperclip", e);
@@ -140,6 +139,24 @@ public class PaperclipRunner {
         }
 
         return Optional.empty();
+    }
+
+    /**
+     * Get Paper / Minecraft library paths.
+     * Plugin downloads their libraries in the libraries folder. it can use same library but different version.
+     * on runtime, it will cause issue. but on bootstrap, it can cause classpath conflict.
+     *
+     * @return filtered library paths.
+     */
+    private static Path[] getLibraryPaths(ClassLoader loader) {
+        try (final var is = new BufferedReader(new InputStreamReader(Objects.requireNonNull(loader.getResourceAsStream("META-INF/libraries.list"))))) {
+            Path libraryPath = Path.of("libraries");
+            // We dont need hash / url
+            return is.lines().map(line -> libraryPath.resolve(line.split("\t")[2])).toArray(Path[]::new);
+        } catch (Exception e) {
+            Log.error(LogCategory.GAME_PROVIDER, "Failed to read library paths from paperclip", e);
+            return new Path[0];
+        }
     }
 
     /**
@@ -185,9 +202,4 @@ public class PaperclipRunner {
 
         return Boolean.getBoolean(name);
     }
-
-    public static Path getPaperclipPath() {
-        return paperclipPath;
-    }
-
 }

--- a/src/main/java/com/floweytf/fabricpaperloader/paperclip/VersionInfo.java
+++ b/src/main/java/com/floweytf/fabricpaperloader/paperclip/VersionInfo.java
@@ -2,13 +2,15 @@ package com.floweytf.fabricpaperloader.paperclip;
 
 import org.jetbrains.annotations.Nullable;
 
+import java.nio.file.Path;
+
 /**
  * The version of paper.
  *
  * @param version The Minecraft version, like 1.19.4 or 1.20.
  * @param hash    The hash of the jar, used to distinguish paper's own builds.
  */
-public record VersionInfo(String version, @Nullable String hash) {
+public record VersionInfo(String version, @Nullable String hash, Path[] requiredLibraries, Path serverJarPath) {
     public String rawVersion() {
         return version + "+" + hash;
     }


### PR DESCRIPTION
the loader always throws a `NoSuchMethodError` or `NoClasDefFoundError` when the plugin downlods a different version of a library. (for example, MythicMob. they use kyori-component 4.16 which was released 3 years ago!!!)

to fix this issue, i made `LibraryClassifier` only add newest version of a library during classification. 
this solution will not resolve all of classpath conflicts, but it's better than nothing.

resolves #2 